### PR TITLE
CI: fix linting and add missing scenarios to compat tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,10 +55,11 @@ jobs:
         scenario:
           - ember-lts-3.4
           - ember-lts-3.8
-          # These are the 3.x LTS's we should *add*
-          # - ember-lts-3.24
-          # - ember-lts-3.28
-          # currently failing b/c they're on Ember v4
+          - ember-lts-3.12
+          - ember-lts-3.16
+          - ember-lts-3.20
+          - ember-lts-3.24
+          - ember-lts-3.28
           # - ember-release
           # - ember-beta
           # - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -23,6 +23,46 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.12.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.28',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0'
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
+    "lint": "yarn lint:js && yarn lint:hbs",
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",


### PR DESCRIPTION
Add scenarios for all Ember LTS releases from 3.12 to 3.28. Does not
yet re-enable release, beta, or canary since this is not yet ready for
Ember v4.

Also add `lint` command to `package.json` so tests actually... test.